### PR TITLE
Call raise_error on subject to catch the error.

### DIFF
--- a/spec/defines/create_domain_spec.rb
+++ b/spec/defines/create_domain_spec.rb
@@ -114,9 +114,7 @@ describe 'glassfish::create_domain' do
     end
     
     it do 
-      expect {
-        contain_domain('test')
-      }.to raise_error(Puppet::Error, /is not a boolean/)
+      expect { subject }.to raise_error(Puppet::Error, /is not a boolean/)
     end
   end
   

--- a/spec/defines/create_service_spec.rb
+++ b/spec/defines/create_service_spec.rb
@@ -139,9 +139,7 @@ describe 'glassfish::create_service' do
       let(:params) { default_params }
         
       it do
-        expect {
-          contain_file('test_servicefile')
-        }.to raise_error(Puppet::Error, /OSFamily Suse not supported/)
+        expect { subject }.to raise_error(Puppet::Error, /OSFamily Suse not supported/)
       end
          
     end


### PR DESCRIPTION
This should help, the create_service_spec.rb fails on another point because you use the fail function in a selector's default (for more info, see http://projects.puppetlabs.com/issues/4598). After you fix that, it should be fine.
