### PR TITLE
need to add a restart domain after enable secure admin

### DIFF
--- a/lib/puppet/provider/domain/asadmin.rb
+++ b/lib/puppet/provider/domain/asadmin.rb
@@ -23,6 +23,7 @@ Puppet::Type.type(:domain).provide(:asadmin,
       # Enable secure admin if required and domain started
       if @resource[:enablesecureadmin] == :true
         asadmin_exec(['enable-secure-admin'])
+        asadmin_exec(['restart-domain', @resource[:name]])
       end
     end
   end

--- a/spec/unit/puppet/provider/domain/asadmin_spec.rb
+++ b/spec/unit/puppet/provider/domain/asadmin_spec.rb
@@ -51,6 +51,9 @@ describe Puppet::Type.type(:domain).provider(:asadmin) do
       domain.provider.expects("`").
         with("su - glassfish -c \"asadmin --port 8048 --user admin --passwordfile /tmp/asadmin.pass enable-secure-admin\"").
         returns("Command enable-secure-admin executed successfully.")
+      domain.provider.expects("`").
+        with("su - glassfish -c \"asadmin --port 8048 --user admin --passwordfile /tmp/asadmin.pass restart-domain test\"").
+        returns("Command restart-domain executed successfully.")
       domain.provider.create
     end
     
@@ -89,6 +92,9 @@ describe Puppet::Type.type(:domain).provider(:asadmin) do
       domain.provider.expects("`").
         with("su - glassfish -c \"asadmin --port 8048 --user admin --passwordfile /tmp/asadmin.pass enable-secure-admin\"").
         returns("Command enable-secure-admin executed successfully.")
+      domain.provider.expects("`").
+        with("su - glassfish -c \"asadmin --port 8048 --user admin --passwordfile /tmp/asadmin.pass restart-domain test\"").
+        returns("Command restart-domain executed successfully.")
       domain.provider.create
     end
   end


### PR DESCRIPTION
it would appear that using this module with secure admin enabled the glassfish domain comes up without secure admin enabled. This is probably not expected behavior - therefore we need to restart the domain before going further
