### PR TITLE
Fix for escaped semi-colons in jvm option

### DIFF
--- a/lib/puppet/provider/jvmoption/asadmin.rb
+++ b/lib/puppet/provider/jvmoption/asadmin.rb
@@ -25,11 +25,14 @@ Puppet::Provider::Asadmin) do
     args = Array.new
     args << "list-jvm-options"
     args << "--target" << @resource[:target] if @resource[:target]
+    
+    #Remove escaped semi-colons for matching the jvm option name
+    name = @resource[:name].sub "\\:" , ":"
 
     asadmin_exec(args).each do |line|
       line.sub!(/-XX: ([^\ ]+)/, '-XX:+\1')
       if line.match(/^-.[^\ ]+/)
-        return true if @resource[:name] == line.chomp
+        return true if name == line.chomp
       end
     end
     return false

--- a/lib/puppet/provider/set/asadmin.rb
+++ b/lib/puppet/provider/set/asadmin.rb
@@ -15,9 +15,14 @@ Puppet::Type.type(:set).provide(:asadmin, :parent =>
   end
 
   def exists?
-    asadmin_exec(["get #{@resource[:name]}"]).each do |line|
-      return true if "#{@resource[:name]}=#{@resource[:value]}" == line.chomp
+    begin
+      asadmin_exec(["get #{@resource[:name]}"]).each do |line|
+        return true if "#{@resource[:name]}=#{@resource[:value]}" == line.chomp
+      end
+      return false
+    rescue Exception => msg
+      #We need to allow the set command to continue if the variable is not found.
+      return false
     end
-    return false
   end
 end

--- a/lib/puppet/type/jvmoption.rb
+++ b/lib/puppet/type/jvmoption.rb
@@ -8,7 +8,7 @@ Puppet::Type.newtype(:jvmoption) do
     isnamevar
     
     validate do |value|
-      unless value =~ /^-(?:[\w\-.:+])+(?:=[\w\-\.\/${}]+)?$/
+      unless value =~ /^-(?:[\w\-.:\\+])+(?:=[\w\-\.\/${}\\:]+)?$/
          raise ArgumentError, "%s is not a valid JVM option." % value
       end
     end

--- a/spec/unit/puppet/type/jvmoption_spec.rb
+++ b/spec/unit/puppet/type/jvmoption_spec.rb
@@ -43,6 +43,14 @@ describe Puppet::Type.type(:jvmoption) do
       it "should support $ values" do
         described_class.new(:option => '-Djavax.net.ssl.trustStore=${com.sun.aas.instanceRoot}/config/cacerts.jks', :ensure => :present)[:option].should == '-Djavax.net.ssl.trustStore=${com.sun.aas.instanceRoot}/config/cacerts.jks'
       end
+      
+      it "should support \: values in the option name" do
+        described_class.new(:option => '-XX\:MaxPermSize=512m', :ensure => :present)[:option].should == '-XX\:MaxPermSize=512m'
+      end
+      
+      it "should support \: values in the option value" do
+        described_class.new(:option => '-Dtest.url=http\:www.gmail.com', :ensure => :present)[:option].should == '-Dtest.url=http\:www.gmail.com'
+      end
 
       it "should not support spaces" do
         expect { described_class.new(:option => '-X Option', :ensure => :present) }.to raise_error(Puppet::Error, /-X Option is not a valid JVM option/)


### PR DESCRIPTION
I need the JVM options to support escaped semi-colons for URL values
and -XX\:MaxPermSize setting.