### PR TITLE
Support redeploying applications

### DIFF
--- a/lib/puppet/provider/application/asadmin.rb
+++ b/lib/puppet/provider/application/asadmin.rb
@@ -33,4 +33,14 @@ Puppet::Provider::Asadmin) do
     end
     return false
   end
+
+  def redeploy
+    args = Array.new
+    args << "redeploy"
+    args << "--name" << @resource[:name]
+    args << @resource[:source]
+
+    asadmin_exec(args)
+  end
+
 end

--- a/lib/puppet/type/application.rb
+++ b/lib/puppet/type/application.rb
@@ -87,7 +87,14 @@ Puppet::Type.newtype(:application) do
   validate do
     raise Puppet::Error, 'Source is required.' if self[:source].nil? and self[:ensure] == :present
   end
-  
+
+  # Redeploy the application on a refresh signal
+  def refresh
+    if self[:ensure] == :present and provider.exists? then
+      provider.redeploy
+    end
+  end
+
   # Autorequire the user running command
   autorequire(:user) do
     self[:user]    

--- a/spec/unit/puppet/provider/application/asadmin_spec.rb
+++ b/spec/unit/puppet/provider/application/asadmin_spec.rb
@@ -75,4 +75,13 @@ describe Puppet::Type.type(:application).provider(:asadmin) do
       application.provider.destroy
     end
   end
+
+  describe "when refreshing a resource" do
+    it "should redeploy an application" do
+      application.provider.expects("`").
+        with("su - glassfish -c \"asadmin --port 8048 --user admin redeploy --name test /tmp/test.war\"").
+        returns("Application deployed with name test. \nCommand redeploy executed successfully. \n")
+      application.provider.redeploy
+    end
+  end
 end

--- a/spec/unit/puppet/type/application_spec.rb
+++ b/spec/unit/puppet/type/application_spec.rb
@@ -170,7 +170,19 @@ describe Puppet::Type.type(:application) do
       end
     end
   end  
-    
+
+  describe "when refreshing" do
+    describe "an application that isn't deployed" do
+      it "should not be refreshed" do
+      end
+    end
+
+    describe "an application that is deployed" do
+      it "should be refreshed" do
+      end
+    end
+  end
+
   describe "when autorequiring" do    
     describe "user autorequire" do
       let :application do


### PR DESCRIPTION
I needed to have Puppet run the asadmin redeploy command when the source jar gets updated, so implemented refresh behaviour in the `application` type and provider.

Tests written and passing, but not quite complete. The provider is covered, but not the type: at present I'm not sure what the correct rspec incantations are to mock the provider and set expectations. Other modules I've looked at for reference do so in quite a different style. Happy to work with any pointers you could give in this area and complete the test coverage.
