### PR TITLE
Add support for passing properties to javamailresource

### DIFF
--- a/lib/puppet/provider/javamailresource/asadmin.rb
+++ b/lib/puppet/provider/javamailresource/asadmin.rb
@@ -21,9 +21,9 @@ Puppet::Type.type(:javamailresource).provide(:asadmin, :parent => Puppet::Provid
 
   def exists?
     asadmin_exec(["list-javamail-resources"]).each do |line|
-      return true if @resource[:name] == line.chomp
+      return true if @resource[:name] == line.strip
     end
     return false
   end
-  
+
 end

--- a/lib/puppet/provider/javamailresource/asadmin.rb
+++ b/lib/puppet/provider/javamailresource/asadmin.rb
@@ -9,6 +9,10 @@ Puppet::Type.type(:javamailresource).provide(:asadmin, :parent => Puppet::Provid
     args << "--mailhost" << @resource[:mailhost]
     args << "--mailuser" << @resource[:mailuser] if @resource[:mailuser]
     args << "--fromaddress" << @resource[:fromaddress]
+    if hasProperties? @resource[:properties]
+      args << "--property"
+      args << "\'#{prepareProperties @resource[:properties]}\'"
+    end
     args << @resource[:name]
     asadmin_exec(args)
   end

--- a/lib/puppet/provider/javamailresource/asadmin.rb
+++ b/lib/puppet/provider/javamailresource/asadmin.rb
@@ -7,7 +7,7 @@ Puppet::Type.type(:javamailresource).provide(:asadmin, :parent => Puppet::Provid
     args << "create-javamail-resource"
     args << "--target" << @resource[:target] if @resource[:target]
     args << "--mailhost" << @resource[:mailhost]
-    args << "--mailuser" << @resource[:mailuser]
+    args << "--mailuser" << @resource[:mailuser] if @resource[:mailuser]
     args << "--fromaddress" << @resource[:fromaddress]
     args << @resource[:name]
     asadmin_exec(args)

--- a/lib/puppet/type/javamailresource.rb
+++ b/lib/puppet/type/javamailresource.rb
@@ -26,12 +26,16 @@ Puppet::Type.newtype(:javamailresource) do
   end
 
   newparam(:target) do
-    desc "This option helps specify the target to which you  are deploying. 
-    Valid options are: server, domain, [cluster name], [instance name]. 
+    desc "This option helps specify the target to which you  are deploying.
+    Valid options are: server, domain, [cluster name], [instance name].
     Defaults to: server"
     defaultto "server"
   end
-  
+
+  newparam(:properties) do
+    desc "The properties. Ex. port=1234 Seperate multiple pairs using :"
+  end
+
   newparam(:portbase) do
     desc "The Glassfish domain port base. Default: 4800"
     defaultto '4800'

--- a/spec/unit/puppet/provider/javamailresource/asadmin_spec.rb
+++ b/spec/unit/puppet/provider/javamailresource/asadmin_spec.rb
@@ -55,6 +55,14 @@ describe Puppet::Type.type(:javamailresource).provider(:asadmin) do
         returns("Mail Resource test created. \nCommand create-javamail-resource executed successfully. \n")
       javamailresource.provider.create
     end
+
+    it "should be possible to pass properties" do
+      javamailresource[:properties] = 'port=12345'
+      javamailresource.provider.expects("`").
+        with("su - glassfish -c \"asadmin --port 4848 --user admin create-javamail-resource --target server --mailhost localhost --fromaddress noreply@example.com --property 'port=12345' test\"").
+        returns("Mail Resource test created. \nCommand create-javamail-resource executed successfully. \n")
+      javamailresource.provider.create
+    end
   end
 
   describe "when destroying a resource" do

--- a/spec/unit/puppet/provider/javamailresource/asadmin_spec.rb
+++ b/spec/unit/puppet/provider/javamailresource/asadmin_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:javamailresource).provider(:asadmin) do
+
+  before :each do
+    Puppet::Type.type(:javamailresource).stubs(:defaultprovider).returns described_class
+    Puppet.features.expects(:root?).returns(true).once
+  end
+
+  let :javamailresource do
+    Puppet::Type.type(:javamailresource).new(
+      :name        => "test",
+      :mailhost    => "localhost",
+      :fromaddress => 'noreply@example.com',
+      :asadminuser => 'admin',
+      :user        => 'glassfish',
+      :provider    => provider
+    )
+  end
+
+  let :provider do
+    described_class.new(
+      :name => 'test'
+    )
+  end
+
+  describe "when asking exists?" do
+    it "should return true if resource is present" do
+      javamailresource.provider.expects("`").
+        with("su - glassfish -c \"asadmin --port 4848 --user admin list-javamail-resources\"").
+        returns("test \nCommand list-javamail-resources executed successfully.")
+      javamailresource.provider.should be_exists
+    end
+
+    it "should return false if resource is absent" do
+      javamailresource.provider.expects("`").
+        with("su - glassfish -c \"asadmin --port 4848 --user admin list-javamail-resources\"").
+        returns("Nothing to list \nCommand list-javamail-resources executed successfully. \n")
+      javamailresource.provider.should_not be_exists
+    end
+  end
+
+  describe "when creating a resource" do
+    it "should be able to create a javamailresource without passing mailuser" do
+      javamailresource.provider.expects("`").
+        with("su - glassfish -c \"asadmin --port 4848 --user admin create-javamail-resource --target server --mailhost localhost --fromaddress noreply@example.com test\"").
+        returns("Mail Resource test created. \nCommand create-javamail-resource executed successfully. \n")
+      javamailresource.provider.create
+    end
+
+    it "should be able to create a javamailresource with passing mailuser" do
+      javamailresource[:mailuser] = "testuser"
+      javamailresource.provider.expects("`").
+        with("su - glassfish -c \"asadmin --port 4848 --user admin create-javamail-resource --target server --mailhost localhost --mailuser testuser --fromaddress noreply@example.com test\"").
+        returns("Mail Resource test created. \nCommand create-javamail-resource executed successfully. \n")
+      javamailresource.provider.create
+    end
+  end
+
+  describe "when destroying a resource" do
+    it "should be able to destroy an javamailresource" do
+      javamailresource.provider.set(:ensure => :absent)
+      javamailresource.provider.expects("`").
+        with("su - glassfish -c \"asadmin --port 4848 --user admin delete-javamail-resource test\"").
+        returns("Mail resource test deleted. \nCommand delete-javamail-resource executed successfully. \n")
+      javamailresource.provider.destroy
+    end
+  end
+end

--- a/spec/unit/puppet/type/javamailresource_spec.rb
+++ b/spec/unit/puppet/type/javamailresource_spec.rb
@@ -62,9 +62,16 @@ describe Puppet::Type.type(:javamailresource) do
         described_class.new(:name => 'test')[:ensure].should == nil
       end
     end
-    
+
+    describe "for properties" do
+      it "should support a value" do
+        described_class.new(:name => 'test', :properties => 'port=1234',
+          :ensure => 'present')[:properties].should == 'port=1234'
+      end
+    end
+
     # TODO: Add tests for mailhost, fromaddress and mailuser
-    
+
     describe "for portbase" do
       it "should support a numerical value" do
         described_class.new(:name => 'test', :portbase => '8000', :ensure => 'present')[:portbase].should == 8000


### PR DESCRIPTION
This PR also includes the changes from PR #56 . I had to do that because there were no tests at all for the javamailresource, and I needed the tests to confirm the change in this PR.

So, #56 should be merged before this one! 

Anyhow, I've added support for passing properties to the javamailresource. This is done in the same way as for the connection pools. The properties are used for example for specifying a non-standard SMTP-port.