### PR TITLE
Refs #59 - Support escaped quotation marks / spaces.

### DIFF
--- a/lib/puppet/provider/asadmin.rb
+++ b/lib/puppet/provider/asadmin.rb
@@ -51,8 +51,8 @@ class Puppet::Provider::Asadmin < Puppet::Provider
   end
 
   def escape(value)
-    # Add three backslashes to escape the colon
-    return value.gsub(/:/) { '\\:' }
+    # Add backslashes to colons and already-escaped qoutes.
+    return value.gsub(/:/){ '\\:' }.gsub(/\"/) { '\\\\"' }
   end
   
   # def exists?

--- a/lib/puppet/provider/jvmoption/asadmin.rb
+++ b/lib/puppet/provider/jvmoption/asadmin.rb
@@ -27,8 +27,9 @@ Puppet::Provider::Asadmin) do
     args << "list-jvm-options"
     args << "--target" << @resource[:target] if @resource[:target]
 
-    #Remove escaped semi-colons for matching the jvm option name
+    #Remove escaped semi-colons and qoutes for matching the jvm option name
     name = @resource[:name].sub "\\:" , ":"
+    name = name.gsub "\\\"" , "\""
 
     asadmin_exec(args).each do |line|
       line.sub!(/-XX: ([^\ ]+)/, '-XX:+\1')

--- a/lib/puppet/type/jvmoption.rb
+++ b/lib/puppet/type/jvmoption.rb
@@ -10,8 +10,8 @@ Puppet::Type.newtype(:jvmoption) do
     isnamevar
 
     validate do |value|
-      unless value =~ /^-(?:[\w\-.:\\+])+(?:=[\w\-\.\/${}\\:]+)?$/
-         raise ArgumentError, "%s is not a valid JVM option." % value
+      unless value =~ /^-(?:[\w\-.:\\+])+(?:=[\w\-\.\/${}\\:]+|=\\\".*\\\")?$/
+        raise ArgumentError, "%s is not a valid JVM option." % value
       end
     end
   end

--- a/spec/unit/puppet/type/jvmoption_spec.rb
+++ b/spec/unit/puppet/type/jvmoption_spec.rb
@@ -52,8 +52,13 @@ describe Puppet::Type.type(:jvmoption) do
         described_class.new(:option => '-Dtest.url=http\:www.gmail.com', :ensure => :present)[:option].should == '-Dtest.url=http\:www.gmail.com'
       end
 
-      it "should not support spaces" do
+      it "should not support spaces in the option name" do
         expect { described_class.new(:option => '-X Option', :ensure => :present) }.to raise_error(Puppet::Error, /-X Option is not a valid JVM option/)
+        expect { described_class.new(:option => '-X Option=value', :ensure => :present) }.to raise_error(Puppet::Error, /-X Option=value is not a valid JVM option/)
+      end
+
+      it "should support spaces contained within escaped double-qoutes in an option value" do
+        described_class.new(:option => '-XOption=\"a value\"', :ensure => :present)[:option].should == '-XOption=\"a value\"'
       end
     end
 


### PR DESCRIPTION
Basically, to allow for JVM options like "`-XX\:OnOutOfMemoryError=\"kill -9 %p\"`" as per issue #59.  Hopefully you think the changes and tests are reasonable -- just let me know if you want anything else added before merging it in.
