### PR TITLE
Feature/rename_application resource for Puppet 4.x support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,17 +16,11 @@ env:
   - PUPPET_VERSION="~> 3.7.0" PARSER="future"
   - PUPPET_VERSION="~> 3.8.0"
   - PUPPET_VERSION="~> 3.8.0" PARSER="future"
-  - PUPPET_VERSION="~> 4.1.0"
-  - PUPPET_VERSION="~> 4.2.0"
-  - PUPPET_VERSION="~> 4.3.0"
+  - PUPPET_VERSION="~> 4.0"
 matrix:
   exclude:
   - rvm: 1.8.7
-    env: PUPPET_VERSION="~> 4.1.0"
-  - rvm: 1.8.7
-    env: PUPPET_VERSION="~> 4.2.0"
-  - rvm: 1.8.7
-    env: PUPPET_VERSION="~> 4.3.0"
+    env: PUPPET_VERSION="~> 4.0"
   - rvm: 2.2
     env: PUPPET_VERSION="~> 3.7.0"
   - rvm: 2.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,31 +4,29 @@ cache: bundler
 rvm: 
   - 1.8.7
   - 1.9.3
-  - 2.0
   - 2.1
   - 2.2
-bundler_args: --without system_tests
+  - 2.3
+bundler_args: --without system_tests --without development
 before_install: rm Gemfile.lock || true
 script: bundle exec rake test
 sudo: false
 env:
-  - PUPPET_VERSION="~> 3.7.0"
-  - PUPPET_VERSION="~> 3.7.0" PARSER="future"
-  - PUPPET_VERSION="~> 3.8.0"
-  - PUPPET_VERSION="~> 3.8.0" PARSER="future"
+  - PUPPET_VERSION="~> 3.0" STRICT_VARIABLES="yes"
+  - PUPPET_VERSION="~> 3.0" STRICT_VARIABLES="yes" FUTURE_PARSER="yes"
   - PUPPET_VERSION="~> 4.0"
 matrix:
   exclude:
   - rvm: 1.8.7
     env: PUPPET_VERSION="~> 4.0"
   - rvm: 2.2
-    env: PUPPET_VERSION="~> 3.7.0"
+    env: PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES="yes"
   - rvm: 2.2
-    env: PUPPET_VERSION="~> 3.7.0" PARSER="future"
+    env: PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES="yes" FUTURE_PARSER="yes"
   - rvm: 2.2
-    env: PUPPET_VERSION="~> 3.8.0"
+    env: PUPPET_VERSION="~> 3.8.0" STRICT_VARIABLES="yes"
   - rvm: 2.2
-    env: PUPPET_VERSION="~> 3.8.0" PARSER="future"
+    env: PUPPET_VERSION="~> 3.8.0" STRICT_VARIABLES="yes" FUTURE_PARSER="yes"
 notifications:
   email:
     - fatmcgav@gmail.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rvm:
   - 1.9.3
   - 2.1
   - 2.2
-  - 2.3
+  # - 2.3
 bundler_args: --without system_tests --without development
 before_install: rm Gemfile.lock || true
 script: bundle exec rake test

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,30 +2,36 @@
 language: ruby
 cache: bundler
 rvm: 
-  - 1.8.7
+  # - 1.8.7
   - 1.9.3
   - 2.1
   - 2.2
-  # - 2.3
-bundler_args: --without system_tests --without development
-before_install: rm Gemfile.lock || true
+  - 2.3.1
+bundler_args: --without system_tests development
+before_install:
+  - bundle -v
+  - rm Gemfile.lock || true
+  - gem update --system
+  - gem update bundler
+  - gem --version
+  - bundle -v
 script: bundle exec rake test
 sudo: false
 env:
   - PUPPET_VERSION="~> 3.0" STRICT_VARIABLES="yes"
   - PUPPET_VERSION="~> 3.0" STRICT_VARIABLES="yes" FUTURE_PARSER="yes"
-  - PUPPET_VERSION="~> 4.0"
+  - PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes"
 matrix:
   exclude:
-  - rvm: 1.8.7
-    env: PUPPET_VERSION="~> 4.0"
+  # - rvm: 1.8.7
+  #   env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES="yes"
   - rvm: 2.2
     env: PUPPET_VERSION="~> 3.0" STRICT_VARIABLES="yes"
   - rvm: 2.2
     env: PUPPET_VERSION="~> 3.0" STRICT_VARIABLES="yes" FUTURE_PARSER="yes"
-  - rvm: 2.3
+  - rvm: 2.3.1
     env: PUPPET_VERSION="~> 3.0" STRICT_VARIABLES="yes"
-  - rvm: 2.3
+  - rvm: 2.3.1
     env: PUPPET_VERSION="~> 3.0" STRICT_VARIABLES="yes" FUTURE_PARSER="yes"
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,13 +20,13 @@ matrix:
   - rvm: 1.8.7
     env: PUPPET_VERSION="~> 4.0"
   - rvm: 2.2
-    env: PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES="yes"
+    env: PUPPET_VERSION="~> 3.0" STRICT_VARIABLES="yes"
   - rvm: 2.2
-    env: PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES="yes" FUTURE_PARSER="yes"
-  - rvm: 2.2
-    env: PUPPET_VERSION="~> 3.8.0" STRICT_VARIABLES="yes"
-  - rvm: 2.2
-    env: PUPPET_VERSION="~> 3.8.0" STRICT_VARIABLES="yes" FUTURE_PARSER="yes"
+    env: PUPPET_VERSION="~> 3.0" STRICT_VARIABLES="yes" FUTURE_PARSER="yes"
+  - rvm: 2.3
+    env: PUPPET_VERSION="~> 3.0" STRICT_VARIABLES="yes"
+  - rvm: 2.3
+    env: PUPPET_VERSION="~> 3.0" STRICT_VARIABLES="yes" FUTURE_PARSER="yes"
 notifications:
   email:
     - fatmcgav@gmail.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rvm:
   - 2.0
   - 2.1
   - 2.2
-bundler_args: --without development
+bundler_args: --without system_tests
 before_install: rm Gemfile.lock || true
 script: bundle exec rake test
 sudo: false

--- a/Gemfile
+++ b/Gemfile
@@ -2,25 +2,19 @@
 
 source "https://rubygems.org"
 
-if ENV.key?('PUPPET_VERSION')
-	puppetversion = ENV['PUPPET_VERSION']
-else
-	puppetversion = ['~> 3.8.0']
-end
-
-gem 'rake'
+gem 'rake', '<11.0'
+gem 'puppet', ENV["PUPPET_VERSION"] || "~> 3.8"
 
 group :test do
-  gem 'puppet', puppetversion
-  gem 'rspec-core', '< 3.0.1'
-  gem 'rspec', '< 3.0.0'
-  gem 'highline', '~> 1.6.0' # Pin to support Ruby 1.8.7
-  # gem 'rspec-puppet', '2.2.0'
+  # gem 'rspec-core', '< 3.0.1'
+  # gem 'rspec', '< 3.0.0'
+  # gem 'highline', '~> 1.6.0' # Pin to support Ruby 1.8.7
+  gem 'rspec-puppet', '~>2.0'
   gem 'puppetlabs_spec_helper'
   #gem 'puppet-lint', '~>1.1.0'
   gem 'puppet-lint', :git => 'https://github.com/rodjek/puppet-lint.git'
   gem 'puppet-syntax', '~> 1.0'
-  gem 'librarian-puppet', '~> 1.4.0'
+  gem 'librarian-puppet', '< 2.0'
   gem 'simplecov', :platforms => [:ruby_19, :ruby_20]
   gem 'coveralls', :platforms => [:ruby_19, :ruby_20]
   gem 'codeclimate-test-reporter', :platforms => [:ruby_19, :ruby_20]
@@ -29,9 +23,15 @@ end
 group :development do
   gem "travis"
   gem "travis-lint"
+  gem "puppet-blacksmith"
+end
+
+group :system_tests do
   gem "beaker"
   gem "beaker-rspec"
   gem "vagrant-wrapper"
-  gem "puppet-blacksmith"
-  gem "guard-rake"
 end
+
+# json_pure 2.0.2 added a requirement on ruby >= 2. We pin to json_pure 2.0.1
+# if using ruby 1.x
+gem 'json_pure', '<=2.0.1', :require => false if RUBY_VERSION =~ /^1\./

--- a/Gemfile
+++ b/Gemfile
@@ -9,14 +9,15 @@ group :test do
   # gem 'rspec-core', '< 3.0.1'
   # gem 'rspec', '< 3.0.0'
   # gem 'highline', '~> 1.6.0' # Pin to support Ruby 1.8.7
+  gem 'rspec'
   gem 'rspec-puppet', '~>2.0'
   gem 'puppetlabs_spec_helper'
   #gem 'puppet-lint', '~>1.1.0'
   gem 'puppet-lint', :git => 'https://github.com/rodjek/puppet-lint.git'
-  gem 'puppet-syntax', '~> 1.0'
+  gem 'puppet-syntax'
   gem 'librarian-puppet', '< 2.0'
-  gem 'simplecov', :platforms => [:ruby_19, :ruby_20]
-  gem 'coveralls', :platforms => [:ruby_19, :ruby_20]
+  gem 'simplecov', :platforms => [:ruby_20]
+  gem 'coveralls', :platforms => [:ruby_20]
   gem 'codeclimate-test-reporter', :platforms => [:ruby_19, :ruby_20]
 end
 

--- a/lib/puppet/provider/app/asadmin.rb
+++ b/lib/puppet/provider/app/asadmin.rb
@@ -1,7 +1,7 @@
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__),"..","..",".."))
 require 'puppet/provider/asadmin'
 
-Puppet::Type.type(:application).provide(:asadmin, :parent =>
+Puppet::Type.type(:app).provide(:asadmin, :parent =>
 Puppet::Provider::Asadmin) do
   desc "Glassfish application deployment support."
   def create

--- a/lib/puppet/type/app.rb
+++ b/lib/puppet/type/app.rb
@@ -1,6 +1,6 @@
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__),"..","..",".."))
 
-Puppet::Type.newtype(:application) do
+Puppet::Type.newtype(:app) do
   @doc = "Manage applications of Glassfish domains"
   ensurable
 

--- a/manifests/create_instance.pp
+++ b/manifests/create_instance.pp
@@ -94,7 +94,7 @@ define glassfish::create_instance (
       node_name     => $node_name,
       runuser       => $node_user,
       service_name  => $svc_name,
-      require       => Cluster_Instance[$instance_name]
+      require       => Cluster_instance[$instance_name]
     }
   }
 

--- a/spec/defines/create_instance_spec.rb
+++ b/spec/defines/create_instance_spec.rb
@@ -46,7 +46,7 @@ describe 'glassfish::create_instance' do
         'instance_name' => 'test',
         'node_name'     => 'testhost',
         'service_name'  => 'glassfish_test'
-      }).that_requires('Cluster_Instance[test]')
+      }).that_requires('Cluster_instance[test]')
     end
   end
   

--- a/spec/defines/create_instance_spec.rb
+++ b/spec/defines/create_instance_spec.rb
@@ -109,7 +109,7 @@ describe 'glassfish::create_instance' do
         'mode'          => 'instance', 
         'instance_name' => 'test',
         'node_name'     => 'testhost'
-      }).that_requires('Cluster_Instance[test]')
+      }).that_requires('Cluster_instance[test]')
     end
   end
   
@@ -143,7 +143,7 @@ describe 'glassfish::create_instance' do
         'instance_name' => 'test',
         'node_name'     => 'testhost',  
         'service_name'  => 'glassfish_instance'
-      }).that_requires('Cluster_Instance[test]')
+      }).that_requires('Cluster_instance[test]')
     end
   end
   

--- a/spec/defines/create_service_spec.rb
+++ b/spec/defines/create_service_spec.rb
@@ -17,9 +17,14 @@ describe 'glassfish::create_service' do
     let(:facts) { {
       :osfamily => 'RedHat'
     } }
+
+    # Need to eval glassfish class
+    let(:pre_condition) {
+      'include glassfish'
+    }
     
     # Test RedHat osfamily behaviour
-    context 'with a title' do
+    describe 'with a title' do
       let(:title) { 'test' }
       
       # Setup params
@@ -74,8 +79,13 @@ describe 'glassfish::create_service' do
       :osfamily => 'Debian'
     } }
     
+    # Need to eval glassfish class
+    let(:pre_condition) {
+      'include glassfish'
+    }
+
     # Test Debian osfamily behaviour
-    context 'with a title' do
+    describe 'with a title' do
       let(:title) { 'test' }
       
       # Setup params

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,13 +21,6 @@ rescue Exception => e
   warn "Coveralls disabled - #{e}"
 end
 
-# Enable future parser
-if ENV['PARSER'] == 'future'
-  RSpec.configure do |c|
-    c.parser = 'future'
-  end
-end
-
 Dir[File.join(File.dirname(__FILE__), 'support', '*.rb')].each do |support_file|
   require support_file
 end

--- a/spec/unit/puppet/provider/app/asadmin_spec.rb
+++ b/spec/unit/puppet/provider/app/asadmin_spec.rb
@@ -1,14 +1,14 @@
 require 'spec_helper'
 
-describe Puppet::Type.type(:application).provider(:asadmin) do
+describe Puppet::Type.type(:app).provider(:asadmin) do
   
   before :each do
-    Puppet::Type.type(:application).stubs(:defaultprovider).returns described_class
+    Puppet::Type.type(:app).stubs(:defaultprovider).returns described_class
     Puppet.features.expects(:root?).returns(true).once
   end
   
-  let :application do
-    Puppet::Type.type(:application).new(
+  let :app do
+    Puppet::Type.type(:app).new(
       :name        => 'test',
       :ensure      => :present,
       :user        => 'glassfish',
@@ -27,61 +27,61 @@ describe Puppet::Type.type(:application).provider(:asadmin) do
   
   describe "when asking exists?" do
     it "should return true if resource is present" do
-      application.provider.expects("`").
+      app.provider.expects("`").
         with("su - glassfish -c \"asadmin --port 8048 --user admin list-applications server\"").
         returns("test  <web>  \nCommand list-applications executed successfully. \n")
-      application.provider.should be_exists
+      app.provider.should be_exists
     end
 
     it "should return false if resource is absent" do
-      application.provider.expects("`").
+      app.provider.expects("`").
         with("su - glassfish -c \"asadmin --port 8048 --user admin list-applications server\"").
         returns("Nothing to list \nCommand list-applications executed successfully. \n")
-      application.provider.should_not be_exists
+      app.provider.should_not be_exists
     end
   end
 
   describe "when creating a resource" do
     it "should be able to deploy an application without a context root" do
-      application.provider.expects("`").
+      app.provider.expects("`").
         with("su - glassfish -c \"asadmin --port 8048 --user admin deploy --precompilejsp=true --target server --name test /tmp/test.war\"").
         returns("Application deployed with name test. \nCommand deploy executed successfully. \n")
-      application.provider.create
+      app.provider.create
     end
     
     it "should be able to deploy an application with a context root" do
-      application[:contextroot] = 'test'
-      application.provider.expects("`").
+      app[:contextroot] = 'test'
+      app.provider.expects("`").
         with("su - glassfish -c \"asadmin --port 8048 --user admin deploy --precompilejsp=true --target server --contextroot test --name test /tmp/test.war\"").
         returns("Application deployed with name test. \nCommand deploy executed successfully. \n")
-      application.provider.create
+      app.provider.create
     end
     
     it "should be able to deploy an application with a target" do
-      application[:target] = 'testCluster'
-      application.provider.expects("`").
+      app[:target] = 'testCluster'
+      app.provider.expects("`").
         with("su - glassfish -c \"asadmin --port 8048 --user admin deploy --precompilejsp=true --target testCluster --name test /tmp/test.war\"").
         returns("Application deployed with name test. \nCommand deploy executed successfully. \n")
-      application.provider.create
+      app.provider.create
     end
   end
   
   describe "when destroying a resource" do
     it "should be able to undeploy an application" do
-      application.provider.set(:ensure => :absent)
-      application.provider.expects("`").
+      app.provider.set(:ensure => :absent)
+      app.provider.expects("`").
         with("su - glassfish -c \"asadmin --port 8048 --user admin undeploy --target server test\"").
         returns("Command undeploy executed successfully. \n")
-      application.provider.destroy
+      app.provider.destroy
     end
   end
 
   describe "when refreshing a resource" do
     it "should redeploy an application" do
-      application.provider.expects("`").
+      app.provider.expects("`").
         with("su - glassfish -c \"asadmin --port 8048 --user admin redeploy --name test /tmp/test.war\"").
         returns("Application deployed with name test. \nCommand redeploy executed successfully. \n")
-      application.provider.redeploy
+      app.provider.redeploy
     end
   end
 end

--- a/spec/unit/puppet/type/app_spec.rb
+++ b/spec/unit/puppet/type/app_spec.rb
@@ -1,13 +1,13 @@
 require 'spec_helper'
 
-describe Puppet::Type.type(:application) do
+describe Puppet::Type.type(:app) do
 
   before :each do
     described_class.stubs(:defaultprovider).returns providerclass
   end
 
   let :providerclass do
-    described_class.provide(:fake_application_provider) do
+    described_class.provide(:fake_app_provider) do
       attr_accessor :property_hash
       def create; end
       def destroy; end
@@ -215,7 +215,7 @@ describe Puppet::Type.type(:application) do
 
   describe "when autorequiring" do    
     describe "user autorequire" do
-      let :application do
+      let :app do
         described_class.new(
           :name         => 'test',
           :source       => '/tmp/application.ear',
@@ -246,22 +246,22 @@ describe Puppet::Type.type(:application) do
       end
       
       it "should not autorequire a user when no matching user can be found" do
-        catalog.add_resource application
-        application.autorequire.should be_empty
+        catalog.add_resource app
+        app.autorequire.should be_empty
       end
   
       it "should autorequire a matching user" do
-        catalog.add_resource application
+        catalog.add_resource app
         catalog.add_resource user
-        reqs = application.autorequire
+        reqs = app.autorequire
         reqs.size.should == 1
         reqs[0].source.ref.should == user.ref
-        reqs[0].target.ref.should == application.ref
+        reqs[0].target.ref.should == app.ref
       end
     end
   
     describe "file autorequire" do
-      let :application do
+      let :app do
         described_class.new(
           :name         => 'test',
           :source       => '/tmp/application.ear',
@@ -292,22 +292,22 @@ describe Puppet::Type.type(:application) do
       end
       
       it "should not autorequire a file when no matching file can be found" do
-        catalog.add_resource application
-        application.autorequire.should be_empty
+        catalog.add_resource app
+        app.autorequire.should be_empty
       end
     
       it "should autorequire a matching file" do
-        catalog.add_resource application
+        catalog.add_resource app
         catalog.add_resource file
-        reqs = application.autorequire
+        reqs = app.autorequire
         reqs.size.should == 1
         reqs[0].source.ref.should == file.ref
-        reqs[0].target.ref.should == application.ref
+        reqs[0].target.ref.should == app.ref
       end
     end
     
     describe "domain autorequire" do
-      let :application do
+      let :app do
         described_class.new(
           :name         => 'test',
           :source       => '/tmp/application.ear',
@@ -340,20 +340,20 @@ describe Puppet::Type.type(:application) do
       end
       
       it "should not autorequire a domain when no matching domain can be found" do
-        catalog.add_resource application
-        application.autorequire.should be_empty
+        catalog.add_resource app
+        app.autorequire.should be_empty
       end
     
       it "should autorequire a matching domain" do
         # Create catalogue
-        catalog.add_resource application
+        catalog.add_resource app
         # Additional expect for domain resource. 
         Puppet.features.expects(:root?).returns(true).once
         catalog.add_resource domain
-        reqs = application.autorequire
+        reqs = app.autorequire
         reqs.size.should == 1
         reqs[0].source.ref.should == domain.ref
-        reqs[0].target.ref.should == application.ref
+        reqs[0].target.ref.should == app.ref
       end
     end
   end


### PR DESCRIPTION
Rename `application` resource to `app`, as `application` is a reserved keyword in Puppet 4.x
